### PR TITLE
docs: add vagrant reload dependency note

### DIFF
--- a/dev_environment/README.md
+++ b/dev_environment/README.md
@@ -32,28 +32,28 @@ Here is a visual overview:
 # Trying out L3AF
 
 * Edit `config.yaml` to point to the source code on your host machine. This
-  code will be mounted by the virtual machine. Additionally, you may modify
-  the default ports used on the host to access services on the virtual
-  machine. (Note, however, that this document will refer to the default
-  ports.)
+  code will be mounted by the virtual machine. Additionally, you may modify the
+  default ports used on the host to access services on the virtual machine.
+  (Note, however, that this document will refer to the default ports.)
+* If you don't already have the vagant reload plugin, you'll need to install it,
+    `vagrant plugin install vagrant-reload`.
 * Run `vagrant up`. This should take just a few minutes to bring up the
   virtual machine from scratch.
 * Verify that the host can send traffic to a web server running on the VM:
   `hey -n 200 -c 20 http://localhost:18080`. This command should return quickly
   and result in successful HTTP responses (200 OK).
 * Run `vagrant ssh`, this will log you into the virtual machine
-* On the VM, go to `~/code/l3afd` and run `go install .` 
+* On the VM, go to `~/code/l3afd` and run `go install .`
 * On the VM, go to `~/go/bin` and run `l3afd` as root:
-  `./l3afd --config /vagrant/cfg/l3afd.cfg`
+  `sudo ./l3afd --config /vagrant/cfg/l3afd.cfg`
 * On the host, configure L3AFD to execute sample Kernel Functions by running
-  `curl -X POST http://localhost:37080/l3af/configs/v1/update -d "@cfg/payload.json"`.
-  The `payload.json` file can be inspected and modified as desired. For more
-  information on the L3AFD API see the
-  [L3AFD API documentation](https://github.com/l3af-project/l3afd/tree/main/docs/api).
+  `curl -X POST http://localhost:37080/l3af/configs/v1/update -d
+  "@cfg/payload.json"`.  The `payload.json` file can be inspected and modified
+  as desired. For more information on the L3AFD API see the [L3AFD API
+  documentation](https://github.com/l3af-project/l3afd/tree/main/docs/api).
 * Verify the eBPF programs from `payload.json` are running by querying the
-  L3AFD debug API from the host:
-  `curl http://localhost:38899/kfs/enp0s3`. This command assumes `enp0s3` is a
-  valid network interface on the VM.
+  L3AFD debug API from the host: `curl http://localhost:38899/kfs/enp0s3`. This
+  command assumes `enp0s3` is a valid network interface on the VM.
 * Once again send traffic to the VM web server:
   `hey -n 200 -c 20 http://localhost:18080`. The traffic will now be running
   through the Kernel Functions (which may affect results dramatically depending


### PR DESCRIPTION
I added a note about the `vagrant-reload` plugin being a dependency.

My auto formatter removed whitespace and rewrapped lines.  Can remove those if preferred, or close this altogether if it's not necessary.