### PR TITLE
Discussion: eBPF program & userspace program repo

### DIFF
--- a/discussions/prog_repo.md
+++ b/discussions/prog_repo.md
@@ -1,188 +1,174 @@
-# L3AF Kernel Function Marketplace
+# L3AF eBPF Package Repository
 
-The concept of a L3AF Kernel Function Marketplace is to create a location where
-Kernel Functions from any trusted party can be uploaded and made available for
-others to download.
+The concept of a L3AF eBPF Package Repository is to create a location where
+eBPF Programs from any trusted party can be uploaded and made available for others to download.
 
-In the context of L3AF, we define a Kernel Function a kernel eBPF program with
-an optional, cooperative userspace program.
-
-There are many things to consider. At the highest level, the purpose of this
-discussion is to arrive an conclusions for:
-
-- What should we name it
-- Is the Kernel Function Marketplace part of the L3AF project?
-- What should an initial version look like
-- What should a more mature version look like
+In the context of L3AF, we define an eBPF Package as a kernel space program with
+an optional, cooperative user space program.
 
 # What should we name it
 
-"L3AF Kernel Function Marketplace" has been the name used up to this point and
-will continue to be the name unless changed by the Technical Steering
-Committee.
+"eBPF Package Repository" is the name that has been chosen by the Technical Steering Committee.
 
-This topic is open for discussion.
+# Is the eBPF Package Repository part of the L3AF Project
 
-# Is the Kernel Function Marketplace part of the L3AF Project
+Firstly, we define the "L3AF Project" as the L3AF open-source project that exists
+within The Linux Foundation. When we say "L3AF", we are referring to the entire L3AF Project.
+This is not to be confused with:
 
-Firstly, we define the "L3AF Project" as entire L3AF open source project that
-exists within The Linux Foundation. When we say "L3AF" we are referring to the
-entire L3AF Project. This is not to be configured with:
+- The `l3af-project` GitHub organization
+- The L3AFD daemon, which is a major component of the L3AF Project.
 
-- The `l3af-project` Github organization
-- The L3AFD daemon, which is just one piece of the L3AF Project.
+We consider L3AF to be an entire ecosystem that aims to provide eBPF Programs as a service.
+We've otherwise phrased this as "complete lifecycle management of eBPF programs".
+This definition includes:
 
-We consider L3AF to be an entire ecosystem of Kernel Functions as a
-service. We've otherwise phrased this as "complete lifecycle management of eBPF
-programs." This definition includes:
+- The L3AFD daemon, an orchestrator that provides APIs to launch and manage eBPF programs on a node
+- The L3AF eBPF Package Repository
+- Programs within the eBPF Package Repository
 
-- The L3AFD daemon, which manages and executes eBPF programs on a node
-- The L3AF Kernel Function Marketplace
-- Programs within the Kernel Function Marketplace
+Note, however, that we have no intention of limiting the creation of other public or private
+eBPF Package repositories.
 
-Note, however, that we have no intention of limiting the creation of other
-public or private Kernel Function Marketplaces.
-
-Additionally, we recognize that it may make sense to migrate the Kernel
-Function marketplace (and Kernel Functions within the marketplace) out of the
-L3AF project and into its own project in the future. Doing this initially may
-not make sense (due to L3AF-specific eBPF program chaining mechanics, for
-example), but as L3AF and other projects mature, a platform-agnostic
-marketplace could be useful for multiple projects.
+We recognize that it may make sense to migrate the eBPF Package Repository
+(eBPF Programs within the repository) out of the L3AF Project and into its own
+Linux Foundation project in the future. Doing this initially may not make sense (due to L3AF-specific
+eBPF program chaining implementation for networking programs), but as L3AF and other projects mature,
+a platform-agnostic repository could be useful for multiple projects.
 
 # What should an initial version look like
 
-This sections examines relatively simply ways that we can create a location
-where Kernel Functions from trusted parties can be uploaded and made available
-for others to download.
+This section examines simple ways to create a location where eBPF Programs can be uploaded
+and made available for others to download.
 
 ## A GitHub repository may be sufficient
- 
-We could leverage GitHub:
-- A new GitHub repository could be created to store kernel function source code
-- All submissions could be reviewed by the L3AF team
-- Once approved, users could download the kernel function (source and any build
-  artifacts)
 
-If we use this approach, this GitHub repo could be created under
-github.com/leaf-project.
+We would like to leverage GitHub:
 
-Kernel functions could be arranged by file path and categorized in any number
-of ways. For example, using a schema such as: 
-
-`/{Program Category}/{Program Subcategory}/{Submitter}/{Program Name}`
-
-Could translate to a kernel function being stored at:
-
-`/Security/limits/Walmart/ratelimit`
+- A new GitHub repository will be created to store eBPF program source code
+- All submissions will be manually reviewed by the L3AF team
+- Once approved, programs will be published in the eBPF Package Repository
 
 Another important thing to note is that, initially, code submissions will need
 to conform to L3AF's eBPF program chaining mechanics.
 
 ## To Build or Not to Build
 
-For the initial version, we could choose to not build the Kernel Function
-source code. However, we believe that not providing a build system would
-greatly hinder adoption from both contributors and users. Therefore, we propose
-that the initial version of the marketplace include a automated build system.
+Because of the overhead and support requirements of a full build system, it may not be
+feasible to build the eBPF program source code in the initial version. However, we believe
+this would greatly hinder adoption from both contributors and users. Our proposal, therefore,
+is to have the repository’s initial version include scripts (e.g. Dockerfile for build system images),
+and steps to build eBPF Programs locally.
 
-### Portability
+## eBPF Package Repository of the future
 
-It's hard to discuss a build system without broaching the topic of portability.
-Luckily, the eBPF portability story has improved fairly recently with the
-introduction of eBPF CO-RE.
+Future versions could build on top of the foundation laid by the initial version.
 
-Previous issues with portability and the eBPF CO-RE solution are explained
-here:
+# What should a future version look like
 
-https://nakryiko.com/posts/bpf-portability-and-co-re/
-
-Because a Kernel Function Marketplace would doubtlessly be a place where
-contributed eBPF programs would be downloaded to run on a variety of kernel
-versions, we propose that the marketplace only contain eBPF CO-RE programs. 
-
-The userspace components of kernel functions pose a separate, complicated
-portability obstacle, which is compounded by the desire of the L3AF project to
-support userspace programs in multiple languages. For the initial version of
-the marketplace, it should be sufficient to build (if a compiled language) and
-unit test for the x86_64 platform. The userspace component should also document
-any installation dependencies it has (e.g., MySQL, Grafana, Python libraries,
-etc.). Contributors to the marketplace would be responsible to provide the
-necessary build scripts and configuration. 
+This section examines simple ways to create a location where eBPF Programs from trusted parties
+can be uploaded and made available for others to download. This can also enable users to provide
+rating, reviews, and tags to the packages.
 
 ### Build Process
 
-Ideally, we would build on a common image (and kernel version) for all
-contributed eBPF programs. We believe eBPF CO-RE would allow us to do this.
-Contributors would be expected to keep their code building on the most recent
-image used by our build system.
+Contributed eBPF programs can be built on common images for Linux and other platforms.
+Contributors are expected to build their code using the most recent image used by our build system.
+Contributors could have a choice to build on Linux only or other platforms.
 
-The image used for our build system could be the most recent release of a
-popular Linux server distribution, for example. Here is some information on the
-distros that support eBPF CO-RE be default:
+Build artifacts (i.e., eBPF program bytecode and user space binaries) could be stored
+in a public file storage repository. Users could download the artifacts directly
+from this repository. In fact, such a repository could also be considered the
+eBPF Package Repository, and the source repository could be a separate entity.
 
-https://github.com/libbpf/libbpf#bpf-co-re-compile-once--run-everywhere
+### Portability
 
-Userspace programs would also ideally build on a common image.
+It is hard to discuss a build system without broaching the topic of portability.
+The eBPF portability story has improved recently with the introduction of eBPF CO-RE on Linux.
+Previous issues with portability and the eBPF CO-RE solution are explained here:
 
-Build artifacts (i.e., eBPF program bytecode and userspace binaries) would be
-stored in a public file storage repository. Users could download the build
-artifacts directory from this repository. In fact, such a repository could also
-be considered the Kernel Function Marketplace, and the source repository could
-be a separate entity.
+https://nakryiko.com/posts/bpf-portability-and-co-re/
 
-After building from source, we would then store the build artifacts into an
-package file and sign it. The file would be signed by the L3AF Project.
+Because an eBPF Package Repository is a place from where contributed eBPF programs (byte code)
+can be downloaded to run on a variety of kernel versions, we propose that the repository follows
+best practices for compatibility, such as using eBPF CO-RE for Linux. Similar best practices
+can be followed on non-Linux platforms as they mature and become available.
+The user space components of eBPF programs pose a separate, complicated portability obstacle,
+which is compounded by the desire of the L3AF project to support user space programs in multiple
+languages. For the initial version of the repository, it should be sufficient to build
+(of a compiled language) and unit test for the x86_64 platform. The user space component
+should document any installation dependencies it has (e.g., MySQL, Grafana, Python libraries, etc.).
+Contributors to the repository would be responsible to provide the necessary build scripts
+and configuration.
 
 ### Multiple Versions
 
-Regardless of whether the L3AF project builds programs from source or not,
-Kernel Functions should use semantic versioning. The marketplace should then
-host previous versions (in addition to the current version) in some reasonable
-manner.
+Regardless of whether the package is built from source or not, eBPF programs should use semantic
+versioning. The repository should then host previous versions (in addition to the current version)
+in some reasonable manner.
+
+### Automated Reviews
+
+There can be a mechanism to review source code, using tools to detect like code formatting errors,
+complexity, code issues, and code duplication. Similarly, vulnerability detection
+scanners can be used for artifacts before uploading.
 
 ## Alternative to Hosting and Building Source Code
 
-An alternative to the L3AF project hosting and building contributed source code
-would be for contributors to submit or self-host a signed package containing
-their Kernel Function and any documentation. The L3AF daemon, by default, would
-only download and run Kernel Functions signed by trusted parties.
+An alternative to the L3AF Project hosting and building contributed source code would be for
+contributors to submit or self-host a signed package containing their eBPF programs and any
+documentation. The L3AF daemon, by default, would only download and run eBPF programs signed
+by trusted parties. This provides a nice segue for us to go into the signing section.
 
-## Kernel Function Signing and Verification
+## Signing and Verification
 
-There are two different layers of signing that should be discussed: the signing
-of the kernel eBPF program and the signing of the Kernel Function package (i.e.,
-an archive containing the built eBPF program and any associated userspace
-programs).
+There are three different layers of signing that should be discussed, the signing of the
+kernel eBPF program (i.e., byte code), the signing of the eBPF programs package (i.e., an archive
+containing the built eBPF program and any associated user space programs) and
+signing for Hypervisors (i.e., Virtualization-based Security).
 
-### Signing and Verifying eBPF programs
+### Signing and verifying eBPF programs
 
 There are efforts underway in the eBPF community for how to sign and verify
-eBPF programs:
+Linux eBPF programs, this enables JIT’ed native code:
 
 https://lore.kernel.org/bpf/20211203191844.69709-1-mcroce@linux.microsoft.com/
 https://linuxplumbersconf.org/event/11/contributions/947/
 
-L3AF will use the best practices that are established for signing and verifying
-eBPF programs.
+Similarly, signing mechanism for other platforms are also being explored.
 
-### Signing and Verifying the Kernel Function package
+L3AF can use the best practices that are established for signing and verifying eBPF programs.
 
-At a higher level, we also plan to sign and verify Kernel Function packages.
+### Signing and verifying the eBPF Program package
 
-The package will be signed by its creator using a Private Enterprise Number
-(PEN). L3AF will, by default, verify the package comes from a trusted source
-before executing any files in the package.
+At a higher level, we also plan to sign and verify eBPF Package.
+The package can be signed by its creator using eBPF Package Repository generated/provided
+trusted keys. L3AF can, by default, verify the package comes from a trusted source before executing
+any programs in the package
 
-# Kernel Function Marketplace of the Future
+### Signing for Hypervisors
 
-Future versions of the future could build on top of the foundation laid by the
-initial versions.
+This approach needs to be explored based on hypervisor operating systems security policies.
 
-## User Experience
+### Define trust
 
-A priority for future versions of the marketplace would be to improve the user
-experience.
+In this context, trusted user and contributor is defined as authorised registered user to the
+system, who has credentials to login with RBAC restrictions. Contributor can be given access
+to a set of trusted keys.
+
+### Running L3AFD in trusted mode
+
+The package can be signed by its creator using the trusted keys.
+L3AFD can have a mechanism to verify that the package is signed using trusted keys and loaded accordingly.
+
+### Running L3AFD in normal mode (not trusted)
+
+L3AFD can bypass verification process before loading any eBPF programs, it is the sole responsibility of
+the user to verify and validate the packages.
+
+### User Experience
+
+A priority for future versions of the repository would be to improve the user experience.
 
 Some examples:
 - Frontend website
@@ -190,15 +176,17 @@ Some examples:
 - Rating system
 - Reviews
 - Buying and selling
+- TLS
+- Oauth
 
 ## Closed Source Contributions
 
-If a public Kernel Function Marketplace becomes popular, we can imagine that
-some contributors may wish to monetize their Kernel Functions. In this case, we
-would not be hosting and building the contributors source code and we would be 
-hosting only a signed package containing their Kernel Function.
+If a public eBPF Program Repository becomes popular, we can imagine that
+some contributors may wish to monetize their eBPF Programs. In this case, we
+would not be hosting and building the contributors source code, and we would be
+hosting only a signed package containing their eBPF Programs.
 
 eBPF licensing information can be found below. The document discusses
-"packaging BPF programs with user space applications."
+"Packaging BPF programs with user space applications."
 
 https://www.kernel.org/doc/Documentation/bpf/bpf_licensing.rst

--- a/discussions/prog_repo.md
+++ b/discussions/prog_repo.md
@@ -56,9 +56,9 @@ to conform to L3AF's eBPF program chaining mechanics.
 
 Because of the overhead and support requirements of a full build system, it may not be
 feasible to build the eBPF program source code in the initial version. However, we believe
-this would greatly hinder adoption from both contributors and users. Our proposal, therefore,
-is to have the repository’s initial version include scripts (e.g. Dockerfile for build system images),
-and steps to build eBPF Programs locally.
+not being able to build from source would greatly hinder adoption from both contributors and users.
+Our proposal, therefore, is to have the repository’s initial version include scripts (e.g. Dockerfile
+for build system images), and steps to build eBPF Programs locally (e.g. for x86_64 platforms).
 
 ## eBPF Package Repository of the future
 
@@ -95,9 +95,9 @@ best practices for compatibility, such as using eBPF CO-RE for Linux. Similar be
 can be followed on non-Linux platforms as they mature and become available.
 The user space components of eBPF programs pose a separate, complicated portability obstacle,
 which is compounded by the desire of the L3AF project to support user space programs in multiple
-languages. For the initial version of the repository, it should be sufficient to build
-(of a compiled language) and unit test for the x86_64 platform. The user space component
-should document any installation dependencies it has (e.g., MySQL, Grafana, Python libraries, etc.).
+languages. For the future version of the repository, initially it should be sufficient to build
+(of a compiled language) and unit test for the x86_64 platform. The user space component should document
+any installation dependencies it has (e.g., MySQL, Grafana, Python libraries, etc.).
 Contributors to the repository would be responsible to provide the necessary build scripts
 and configuration.
 

--- a/discussions/prog_repo.md
+++ b/discussions/prog_repo.md
@@ -1,0 +1,197 @@
+# L3AF Kernel Function Marketplace
+
+The concept of a L3AF Kernel Function Marketplace is to create a location where
+Kernel Functions from any trusted party can be uploaded and made available for
+others to download.
+
+In the context of L3AF, we define a Kernel Function a kernel eBPF program with
+an optional, cooperative userspace program.
+
+There are many things to consider. At the highest level, the purpose of this
+discussion is to arrive an conclusions for:
+
+- What should we name it
+- Is the Kernel Function Marketplace part of the L3AF project?
+- What should an initial version look like
+- What should a more mature version look like
+
+# What should we name it
+
+"L3AF Kernel Function Marketplace" has been the name used up to this point and
+will continue to be the name unless changed by the Technical Steering
+Committee.
+
+This topic is open for discussion.
+
+# Is the Kernel Function Marketplace part of the L3AF project
+
+Yes, we consider L3AF to be an entire ecosystem of Kernel Functions as a
+service. We've otherwise phrased this as "complete lifecycle management of eBPF
+programs." This definition includes:
+
+- The L3AFD daemon, which manages and executes eBPF programs on a node
+- The L3AF Kernel Function Marketplace
+- Programs within the Kernel Function Marketplace
+
+Note, however, that we have no intention of limiting the creation of other
+public or private Kernel Function Marketplaces.
+
+Additionally, we recognize that it may make sense to migrate the Kernel
+Function marketplace (and Kernel Functions within the marketplace) out of the
+L3AF project and into its own project in the future. Doing this initially may
+not make sense (due to L3AF-specific eBPF program chaining mechanics, for
+example), but as L3AF and other projects mature, a platform-agnostic
+marketplace could be useful for multiple projects.
+
+# What should an initial version look like
+
+This sections examines relatively simply ways that we can create a location
+where Kernel Functions from trusted parties can be uploaded and made available
+for others to download.
+
+## A GitHub repository may be sufficient
+ 
+We could leverage GitHub:
+- A new GitHub repository could be created to store kernel function source code
+- All submissions could be reviewed by the L3AF team
+- Once approved, users could download the kernel function (source and any build
+  artifacts)
+
+If we use this approach, this GitHub repo could be created under
+github.com/leaf-project.
+
+Kernel functions could be arranged by file path and categorized in any number
+of ways. For example, using a schema such as: 
+
+`/{Program Category}/{Program Subcategory}/{Submitter}/{Program Name}`
+
+Could translate to a kernel function being stored at:
+
+`/Security/limits/Walmart/ratelimit`
+
+Another important thing to note is that, initially, code submissions will need
+to conform to L3AF's eBPF program chaining mechanics.
+
+## To Build or Not to Build
+
+For the initial version, we could choose to not build the Kernel Function
+source code. However, we believe that not providing a build system would
+greatly hinder adoption from both contributors and users. Therefore, we propose
+that the initial version of the marketplace include a automated build system.
+
+### Portability
+
+It's hard to discuss a build system without broaching the topic of portability.
+Luckily, the eBPF portability story has improved fairly recently with the
+introduction of eBPF CO-RE.
+
+Previous issues with portability and the eBPF CO-RE solution are explained
+here:
+
+https://nakryiko.com/posts/bpf-portability-and-co-re/
+
+Because a Kernel Function Marketplace would doubtlessly be a place where
+contributed eBPF programs would be downloaded to run on a variety of kernel
+versions, we propose that the marketplace only contain eBPF CO-RE programs. 
+
+The userspace components of kernel functions pose a separate, complicated
+portability obstacle, which is compounded by the desire of the L3AF project to
+support userspace programs in multiple languages. For the initial version of
+the marketplace, it should be sufficient to build (if a compiled language) and
+unit test for the x86_64 platform. The userspace component should also document
+any installation dependencies it has (e.g., MySQL, Grafana, Python libraries,
+etc.). Contributors to the marketplace would be responsible to provide the
+necessary build scripts and configuration. 
+
+### Build Process
+
+Ideally, we would build on a common image (and kernel version) for all
+contributed eBPF programs. We believe eBPF CO-RE would allow us to do this.
+Contributors would be expected to keep their code building on the most recent
+image used by our build system.
+
+The image used for our build system could be the most recent release of a
+popular Linux server distribution, for example. Here is some information on the
+distros that support eBPF CO-RE be default:
+
+https://github.com/libbpf/libbpf#bpf-co-re-compile-once--run-everywhere
+
+Userspace programs would also ideally build on a common image.
+
+Build artifacts (i.e., eBPF program bytecode and userspace binaries) would be
+stored in a public file storage repository. Users could download the build
+artifacts directory from this repository. In fact, such a repository could also
+be considered the Kernel Function Marketplace, and the source repository could
+be a separate entity.
+
+After building from source, we would then store the build artifacts into an
+package file and sign it. The file would be signed by the L3AF Project.
+
+### Multiple Versions
+
+Regardless of whether the L3AF project builds programs from source or not,
+Kernel Functions should use semantic versioning. The marketplace should then
+host previous versions (in addition to the current version) in some reasonable
+manner.
+
+## Alternative to Hosting and Building Source Code
+
+An alternative to the L3AF project hosting and building contributed source code
+would be for contributors to submit or self-host a signed package containing
+their Kernel Function and any documentation. The L3AF daemon, by default, would
+only download and run Kernel Functions signed by trusted parties.
+
+## Kernel Function Signing and Verification
+
+There are two different layers of signing that should be discussed: the signing
+of the kernel eBPF program and the signing of the Kernel Function package (i.e.,
+an archive containing the built eBPF program and any associated userspace
+programs).
+
+### Signing and Verifying eBPF programs
+
+There are efforts underway in the eBPF community for how to sign and verify
+eBPF programs:
+
+https://lore.kernel.org/bpf/20211203191844.69709-1-mcroce@linux.microsoft.com/
+https://linuxplumbersconf.org/event/11/contributions/947/
+
+L3AF will use the best practices that are established for signing and verifying
+eBPF programs.
+
+### Signing and Verifying the Kernel Function package
+
+At a higher level, we also plan to sign and verify Kernel Function packages.
+
+The package will be signed by its creator using a Private Enterprise Number
+(PEN). L3AF will, by default, verify the package comes from a trusted source
+before executing any files in the package.
+
+# Kernel Function Marketplace of the Future
+
+Future versions of the future could build on top of the foundation laid by the
+initial versions.
+
+## User Experience
+
+A priority for future versions of the marketplace would be to improve the user
+experience.
+
+Some examples:
+- Frontend website
+- Searchable
+- Rating system
+- Reviews
+- Buying and selling
+
+## Closed Source Contributions
+
+If a public Kernel Function Marketplace becomes popular, we can imagine that
+some contributors may wish to monetize their Kernel Functions. In this case, we
+would not be hosting and building the contributors source code and we would be 
+hosting only a signed package containing their Kernel Function.
+
+eBPF licensing information can be found below. The document discusses
+"packaging BPF programs with user space applications."
+
+https://www.kernel.org/doc/Documentation/bpf/bpf_licensing.rst

--- a/discussions/prog_repo.md
+++ b/discussions/prog_repo.md
@@ -89,7 +89,7 @@ Previous issues with portability and the eBPF CO-RE solution are explained here:
 
 https://nakryiko.com/posts/bpf-portability-and-co-re/
 
-Because an eBPF Package Repository is a place from where contributed eBPF programs (byte code)
+Because an eBPF Package Repository is a place from where contributed eBPF programs (byte code or native code)
 can be downloaded to run on a variety of kernel versions, we propose that the repository follows
 best practices for compatibility, such as using eBPF CO-RE for Linux. Similar best practices
 can be followed on non-Linux platforms as they mature and become available.
@@ -141,10 +141,9 @@ L3AF can use the best practices that are established for signing and verifying e
 
 ### Signing and verifying the eBPF Program package
 
-At a higher level, we also plan to sign and verify eBPF Packages.
-The package can be signed by its creator using eBPF Package Repository generated/provided
-trusted keys. L3AF can, by default, verify the package comes from a trusted source before executing
-any programs in the package
+The eBPF package should be signed by using the creators trusted keys. The user should
+then configure L3AF to explicitly trust signed packages with the key creator used. L3AF by default
+will not trust signed packages by any parties.
 
 ### Signing for Hypervisors
 

--- a/discussions/prog_repo.md
+++ b/discussions/prog_repo.md
@@ -31,10 +31,10 @@ Note, however, that we have no intention of limiting the creation of other publi
 eBPF Package repositories.
 
 We recognize that it may make sense to migrate the eBPF Package Repository
-(eBPF Programs within the repository) out of the L3AF Project and into its own
-Linux Foundation project in the future. Doing this initially may not make sense (due to L3AF-specific
-eBPF program chaining implementation for networking programs), but as L3AF and other projects mature,
-a platform-agnostic repository could be useful for multiple projects.
+out of the L3AF Project and into its own Linux Foundation project in the future.
+Doing this initially may not make sense (due to L3AF-specific eBPF program chaining implementation
+for networking programs), but as L3AF and other projects mature, a platform-agnostic repository
+could be useful for multiple projects.
 
 # What should an initial version look like
 
@@ -66,14 +66,14 @@ Future versions could build on top of the foundation laid by the initial version
 
 # What should a future version look like
 
-This section examines simple ways to create a location where eBPF Programs from trusted parties
+This section examines simple ways to create a location where eBPF Packages from trusted parties
 can be uploaded and made available for others to download. This can also enable users to provide
 rating, reviews, and tags to the packages.
 
 ### Build Process
 
-Contributed eBPF programs can be built on common images for Linux and other platforms.
-Contributors are expected to build their code using the most recent image used by our build system.
+Contributed eBPF Packages can be built on common images for Linux and other platforms.
+Contributors are expected to build their code using the most recent images used by our build system.
 Contributors could have a choice to build on Linux only or other platforms.
 
 Build artifacts (i.e., eBPF program bytecode and user space binaries) could be stored
@@ -141,7 +141,7 @@ L3AF can use the best practices that are established for signing and verifying e
 
 ### Signing and verifying the eBPF Program package
 
-At a higher level, we also plan to sign and verify eBPF Package.
+At a higher level, we also plan to sign and verify eBPF Packages.
 The package can be signed by its creator using eBPF Package Repository generated/provided
 trusted keys. L3AF can, by default, verify the package comes from a trusted source before executing
 any programs in the package
@@ -152,8 +152,8 @@ This approach needs to be explored based on hypervisor operating systems securit
 
 ### Define trust
 
-In this context, trusted user and contributor is defined as authorised registered user to the
-system, who has credentials to login with RBAC restrictions. Contributor can be given access
+In this context, a trusted user and contributor is defined as an authorised user registered to the
+system, who has credentials to log in with RBAC restrictions. A contributor can be given access
 to a set of trusted keys.
 
 ### Running L3AFD in trusted mode

--- a/discussions/prog_repo.md
+++ b/discussions/prog_repo.md
@@ -30,7 +30,7 @@ This definition includes:
 Note, however, that we have no intention of limiting the creation of other public or private
 eBPF Package repositories.
 
-We recognize that it may make sense to migrate the eBPF Package Repository
+L3AF Technical Steering Committee recognizes that it may make sense to migrate the eBPF Package Repository
 out of the L3AF Project and into its own Linux Foundation project in the future.
 Doing this initially may not make sense (due to L3AF-specific eBPF program chaining implementation
 for networking programs), but as L3AF and other projects mature, a platform-agnostic repository

--- a/discussions/prog_repo.md
+++ b/discussions/prog_repo.md
@@ -23,9 +23,16 @@ Committee.
 
 This topic is open for discussion.
 
-# Is the Kernel Function Marketplace part of the L3AF project
+# Is the Kernel Function Marketplace part of the L3AF Project
 
-Yes, we consider L3AF to be an entire ecosystem of Kernel Functions as a
+Firstly, we define the "L3AF Project" as entire L3AF open source project that
+exists within The Linux Foundation. When we say "L3AF" we are referring to the
+entire L3AF Project. This is not to be configured with:
+
+- The `l3af-project` Github organization
+- The L3AFD daemon, which is just one piece of the L3AF Project.
+
+We consider L3AF to be an entire ecosystem of Kernel Functions as a
 service. We've otherwise phrased this as "complete lifecycle management of eBPF
 programs." This definition includes:
 


### PR DESCRIPTION
This document is to define what a repository for eBPF programs and their
associated userspace programs should be and how it should operate.

A preview of this document was done in the Jan 5 2022 TSC meeting:
https://wiki.lfnetworking.org/display/L3AF/01-05-2022+TSC+Meeting+Minutes

We expect a lot of feedback and changes to this document; once it has
stabilized, it will move to a GitHub discussion as a proposal.