### PR TITLE
refactor: change network_function to ebpf_program

### DIFF
--- a/dev_environment/cfg/grafana/dashboards/l3af_connection_limiting.json
+++ b/dev_environment/cfg/grafana/dashboards/l3af_connection_limiting.json
@@ -78,7 +78,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": " l3afd_NFMonitorMap{map_name=\"cl_conn_count_0_scalar\",network_function=\"connection-limit\"}",
+          "expr": " l3afd_NFMonitorMap{map_name=\"cl_conn_count_0_scalar\",ebpf_program=\"connection-limit\"}",
           "hide": false,
           "interval": "30s",
           "legendFormat": "{{host}}",
@@ -182,7 +182,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(l3afd_NFMonitorMap{map_name=\"cl_recv_count_map_0_scalar\", network_function=\"connection-limit\"}[2m])) by (host)",
+          "expr": "sum(irate(l3afd_NFMonitorMap{map_name=\"cl_recv_count_map_0_scalar\", ebpf_program=\"connection-limit\"}[2m])) by (host)",
           "hide": false,
           "interval": "30s",
           "legendFormat": "{{host}}",
@@ -286,7 +286,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(l3afd_NFMonitorMap{map_name=\"cl_drop_count_map_0_scalar\", network_function=\"connection-limit\"}[2m])) by (host)",
+          "expr": "sum(irate(l3afd_NFMonitorMap{map_name=\"cl_drop_count_map_0_scalar\", ebpf_program=\"connection-limit\"}[2m])) by (host)",
           "hide": false,
           "interval": "30s",
           "legendFormat": "{{host}}",

--- a/dev_environment/cfg/grafana/dashboards/l3af_connection_limiting.json
+++ b/dev_environment/cfg/grafana/dashboards/l3af_connection_limiting.json
@@ -78,7 +78,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": " l3afd_NFMonitorMap{map_name=\"cl_conn_count_0_scalar\",ebpf_program=\"connection-limit\"}",
+          "expr": "l3afd_NFMonitorMap{map_name=\"cl_conn_count_0_scalar\",ebpf_program=\"connection-limit\"}",
           "hide": false,
           "interval": "30s",
           "legendFormat": "{{host}}",

--- a/dev_environment/cfg/grafana/dashboards/l3af_ebpf_programs.json
+++ b/dev_environment/cfg/grafana/dashboards/l3af_ebpf_programs.json
@@ -74,7 +74,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "l3afd_NFRunning{network_function=~\".*$KF.*\"}",
+          "expr": "l3afd_NFRunning{ebpf_program=~\".*$KF.*\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{host}}:{{direction}}",
@@ -171,7 +171,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(l3afd_NFRunning{network_function=~\".*$KF.*\"})by(direction)",
+          "expr": "sum(l3afd_NFRunning{ebpf_program=~\".*$KF.*\"})by(direction)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{direction}}",
@@ -269,7 +269,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "l3afd_NFStartCount{network_function=~\".*$KF.*\"}",
+          "expr": "l3afd_NFStartCount{ebpf_program=~\".*$KF.*\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{host}}:{{direction}}",
@@ -366,7 +366,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "l3afd_NFStopCount{network_function=~\".*$KF.*\"}",
+          "expr": "l3afd_NFStopCount{ebpf_program=~\".*$KF.*\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{host}}:{{direction}}",

--- a/dev_environment/cfg/grafana/dashboards/l3af_rate_limiting.json
+++ b/dev_environment/cfg/grafana/dashboards/l3af_rate_limiting.json
@@ -80,7 +80,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "l3afd_NFMonitorMap{network_function=\"ratelimiting\",map_name=\"rl_recv_count_map_0_max-rate\"}",
+          "expr": "l3afd_NFMonitorMap{ebpf_program=\"ratelimiting\",map_name=\"rl_recv_count_map_0_max-rate\"}",
           "hide": false,
           "interval": "30s",
           "legendFormat": "{{host}}",
@@ -184,7 +184,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(l3afd_NFMonitorMap{map_name=\"rl_drop_count_map_0_scalar\",network_function=\"ratelimiting\"}[5m])) by (host)",
+          "expr": "sum(irate(l3afd_NFMonitorMap{map_name=\"rl_drop_count_map_0_scalar\",ebpf_program=\"ratelimiting\"}[5m])) by (host)",
           "interval": "",
           "legendFormat": "{{host}}",
           "refId": "A"


### PR DESCRIPTION
This diff changes the `network_function` field in the grafana dashboards to `ebpf_programs`. 
This is inline with the changes performed for: https://github.com/l3af-project/l3afd/issues/201