### PR TITLE
Adding traffic-mirroring in Vagrant and Linux dev-environment

### DIFF
--- a/dev_environment/README.md
+++ b/dev_environment/README.md
@@ -69,7 +69,6 @@ Here is a visual overview:
 * To see the eBPF program metrics, browse to `http://localhost:33000` on the
   host and log in to Grafana with the default username and password of `admin`.
   After logging in you will be able to view the preconfigured dashboards.
-
 * Additional steps for testing out traffic mirroring:
   1. Set `traffic_mirroring: 'true'` in [config.yaml](config.yaml)
   2. Redeploy the Vagrant script (`vagrant reload --provision`) to reflect new changes, such as creation of a GUE tunnel and an additional VM (Collector)

--- a/dev_environment/README.md
+++ b/dev_environment/README.md
@@ -70,7 +70,7 @@ Here is a visual overview:
   host and log in to Grafana with the default username and password of `admin`.
   After logging in you will be able to view the preconfigured dashboards.
 
-* Additional Steps for testing out traffic mirroring:
+* Additional steps for testing out traffic mirroring:
   1. Set `traffic_mirroring: 'true'` in [config.yaml](config.yaml)
   2. Redeploy the Vagrant script (`vagrant reload --provision`) to reflect new changes, such as creation of a GUE tunnel and an additional VM (Collector)
   3. Start traffic mirrroing via `curl -X POST http://localhost:37080/l3af/configs/v1/add -d "@cfg/traffic_mirroring_payload.json"` from the host

--- a/dev_environment/README.md
+++ b/dev_environment/README.md
@@ -50,7 +50,7 @@ Here is a visual overview:
 * On the VM, go to `~/go/bin` and run `l3afd` as root:
   `sudo ./l3afd --config /vagrant/cfg/l3afd.cfg`
 * On the host, configure L3AFD to execute sample eBPF programs by running
-  `curl -X POST http://localhost:37080/l3af/configs/v1/update -d
+  `curl -X POST http://localhost:37080/l3af/configs/v1/add -d
   "@cfg/payload.json"`. The [payload.json](cfg/payload.json) file can be
   inspected and modified as desired. For more information on the L3AFD API see
   the [L3AFD API documentation](https://github.com/l3af-project/l3afd/tree/main/docs/api).
@@ -67,14 +67,11 @@ Here is a visual overview:
   on which eBPF programs are running and how they are configured).  If the rate limiter eBPF program is loaded, this command should output a latency distribution histogram that
   is more distributed.<p align="center"><img src="https://user-images.githubusercontent.com/106849610/179867246-406a2841-5a49-4102-b42c-e9cbf07ce2c3.png" width="400" height="200"/></p>
 * To see the eBPF program metrics, browse to `http://localhost:33000` on the
-  host and login to Grafana with the default username and password of `admin`.
-  After logging in you will be able to view the preconfigured dashboards.
-* To see the eBPF program metrics, browse to `http://localhost:33000` on the
-  host and login to Grafana with the default username and password of `admin`.
+  host and log in to Grafana with the default username and password of `admin`.
   After logging in you will be able to view the preconfigured dashboards.
 * Traffic-mirroring:
   1. Set `traffic_mirroring: 'true'` in [config.yaml](config.yaml)
   2. Redeploy the Vagrant script (`vagrant reload --provision`) to reflect new changes, such as creation of a GUE tunnel and an additional VM (Collector)
-  3. Start traffic mirrroing via `curl -X POST http://localhost:37080/l3af/configs/v1/update -d "@cfg/traffic_mirroring_payload.json"` from the host
-  4. Delete the default route by executing this command (`sudo route del -net 192.168.10.50 gw 192.168.10.1 netmask 255.255.255.255 dev enp0s8`) on l3af-VM as it is not required in the current vagrant environment
+  3. Start traffic mirrroing via `curl -X POST http://localhost:37080/l3af/configs/v1/add -d "@cfg/traffic_mirroring_payload.json"` from the host
+  4. Delete the default route by executing this command (`sudo ip r del 192.168.10.50 via 192.168.10.1 dev enp0s8`) on l3af-VM as it is not required in the current vagrant environment
   5. SSH into Collector VM via `vagrant ssh collector` command and execute `sudo tcpdump -i enp0s8` to see the mirrored-GUE packets and `sudo tcpdump -i gue1` to see the mirrored-original packets when we send traffic to the l3af-VM's web server (`hey -n 200 -c 20 http://localhost:18080`) from the host

--- a/dev_environment/README.md
+++ b/dev_environment/README.md
@@ -69,9 +69,10 @@ Here is a visual overview:
 * To see the eBPF program metrics, browse to `http://localhost:33000` on the
   host and log in to Grafana with the default username and password of `admin`.
   After logging in you will be able to view the preconfigured dashboards.
-* Traffic-mirroring:
+
+* Additional Steps for testing out traffic mirroring:
   1. Set `traffic_mirroring: 'true'` in [config.yaml](config.yaml)
   2. Redeploy the Vagrant script (`vagrant reload --provision`) to reflect new changes, such as creation of a GUE tunnel and an additional VM (Collector)
   3. Start traffic mirrroing via `curl -X POST http://localhost:37080/l3af/configs/v1/add -d "@cfg/traffic_mirroring_payload.json"` from the host
   4. Delete the default route by executing this command (`sudo ip r del 192.168.10.50 via 192.168.10.1 dev enp0s8`) on l3af-VM as it is not required in the current vagrant environment
-  5. SSH into Collector VM via `vagrant ssh collector` command and execute `sudo tcpdump -i enp0s8` to see the mirrored-GUE packets and `sudo tcpdump -i gue1` to see the mirrored-original packets when we send traffic to the l3af-VM's web server (`hey -n 200 -c 20 http://localhost:18080`) from the host
+  5. SSH into Collector VM via `vagrant ssh collector` command and execute `sudo tcpdump -i enp0s8` to see the mirrored-GUE packets and `sudo tcpdump -i gue1` to see the mirrored-original packets when we send traffic to the l3af VM web server (`hey -n 200 -c 20 http://localhost:18080`) from the host

--- a/dev_environment/README.md
+++ b/dev_environment/README.md
@@ -45,7 +45,7 @@ Here is a visual overview:
   `hey -n 200 -c 20 http://localhost:18080`. This command should return quickly
   and result in successful HTTP responses (200 OK).  This command should also return a latency distribution histogram that shows
   most traffic clustered near the top of the graph at very low latency.<p align="center"><img src="https://user-images.githubusercontent.com/106849610/179866166-597bef0d-2f5f-4ae7-89ee-1acdda5fd060.png" width="400" height="200"/></p>
-* Run `vagrant ssh`, this will log you into the virtual machine
+* Run `vagrant ssh l3af`, this will log you into the virtual machine
 * On the VM, go to `~/code/l3afd` and run `make install`
 * On the VM, go to `~/go/bin` and run `l3afd` as root:
   `sudo ./l3afd --config /vagrant/cfg/l3afd.cfg`
@@ -69,3 +69,12 @@ Here is a visual overview:
 * To see the eBPF program metrics, browse to `http://localhost:33000` on the
   host and login to Grafana with the default username and password of `admin`.
   After logging in you will be able to view the preconfigured dashboards.
+* To see the eBPF program metrics, browse to `http://localhost:33000` on the
+  host and login to Grafana with the default username and password of `admin`.
+  After logging in you will be able to view the preconfigured dashboards.
+* Traffic-mirroring:
+  1. Set `traffic_mirroring: 'true'` in [config.yaml](config.yaml)
+  2. Redeploy the Vagrant script (`vagrant reload --provision`) to reflect new changes, such as creation of a GUE tunnel and an additional VM (Collector)
+  3. Start traffic mirrroing via `curl -X POST http://localhost:37080/l3af/configs/v1/update -d "@cfg/traffic_mirroring_payload.json"` from the host
+  4. Delete the default route by executing this command (`sudo route del -net 192.168.10.50 gw 192.168.10.1 netmask 255.255.255.255 dev enp0s8`) on l3af-VM as it is not required in the current vagrant environment
+  5. SSH into Collector VM via `vagrant ssh collector` command and execute `sudo tcpdump -i enp0s8` to see the mirrored-GUE packets and `sudo tcpdump -i gue1` to see the mirrored-original packets when we send traffic to the l3af-VM's web server (`hey -n 200 -c 20 http://localhost:18080`) from the host

--- a/dev_environment/Vagrantfile
+++ b/dev_environment/Vagrantfile
@@ -7,12 +7,6 @@ cfg = YAML.load_file(File.join(
   File.dirname(File.expand_path(__FILE__)),
   "config.yaml"))['configs']
 
-def nat(config)
-  config.vm.provider "virtualbox" do |v|
-    v.customize ["modifyvm", :id, "--nic2", "natnetwork", "--nat-network2", "NATNetwork101"]
-  end
-end
-
 Vagrant.configure("2") do |config|
   config.vm.define "l3af" do |l3af|
 
@@ -33,7 +27,6 @@ Vagrant.configure("2") do |config|
     l3af.vm.box = "ubuntu/focal64"
     if cfg['traffic_mirroring'] == "true"
       l3af.vm.network :private_network, ip: "192.168.10.40", :netmask => "255.255.255.0"
-      nat(config)
     end
     l3af.vm.hostname = "l3af-local-test.local"
     l3af.ssh.forward_agent = true
@@ -111,6 +104,9 @@ Vagrant.configure("2") do |config|
 
   if cfg['traffic_mirroring'] == "true"
     config.vm.define "collector" do |collector|
+      collector.vm.provider "virtualbox" do |vb|
+        vb.memory = "512"
+      end
       collector.vm.network "private_network", ip: "192.168.10.50", :netmask => "255.255.255.0"
       collector.vm.box = "ubuntu/focal64"
       collector.vm.provision "shell", inline: <<-SHELL

--- a/dev_environment/Vagrantfile
+++ b/dev_environment/Vagrantfile
@@ -86,11 +86,12 @@ Vagrant.configure("2") do |config|
 
     # Reboot for updated kernel to load
     l3af.vm.provision :reload
-
     l3af.vm.provision :shell, path: "provision.sh"
 
     # Always start test servers because they aren't managed services
     l3af.vm.provision :shell, path: "start_test_servers.sh", run: 'always'
+    
+   # Provision the GUE interface for traffic mirroring inside the l3af VM
     if cfg['traffic_mirroring'] == "true"
       l3af.vm.provision "shell", inline: <<-SHELL
         modprobe fou
@@ -99,14 +100,15 @@ Vagrant.configure("2") do |config|
         ip link set dev gue1 up
       SHELL
     end
-
   end
 
+  # Provision traffic mirroring collector VM
   if cfg['traffic_mirroring'] == "true"
     config.vm.define "collector" do |collector|
       collector.vm.provider "virtualbox" do |vb|
         vb.memory = "512"
       end
+      
       collector.vm.network "private_network", ip: "192.168.10.50", :netmask => "255.255.255.0"
       collector.vm.box = "ubuntu/focal64"
       collector.vm.provision "shell", inline: <<-SHELL

--- a/dev_environment/Vagrantfile
+++ b/dev_environment/Vagrantfile
@@ -7,84 +7,118 @@ cfg = YAML.load_file(File.join(
   File.dirname(File.expand_path(__FILE__)),
   "config.yaml"))['configs']
 
+def nat(config)
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["modifyvm", :id, "--nic2", "natnetwork", "--nat-network2", "NATNetwork101"]
+  end
+end
+
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.define "l3af" do |l3af|
 
-  # Set boot timeout value
-  config.vm.boot_timeout = 600
+    # Set boot timeout value
+    l3af.vm.boot_timeout = 600
 
-  config.vm.network "forwarded_port", guest: 8080, host: cfg['host_http_port1']
-  config.vm.network "forwarded_port", guest: 8081, host: cfg['host_http_port2']
-  config.vm.network "forwarded_port", guest: 3000, host: cfg['host_grafana_port']
-  config.vm.network "forwarded_port", guest: 9090, host: cfg['host_prometheus_port']
-  config.vm.network "forwarded_port", guest: 7080, host: cfg['host_l3af_config_port']
-  config.vm.network "forwarded_port", guest: 8899, host: cfg['host_l3af_debug_port']
+    l3af.vm.network "forwarded_port", guest: 8080, host: cfg['host_http_port1']
+    l3af.vm.network "forwarded_port", guest: 8081, host: cfg['host_http_port2']
+    l3af.vm.network "forwarded_port", guest: 3000, host: cfg['host_grafana_port']
+    l3af.vm.network "forwarded_port", guest: 9090, host: cfg['host_prometheus_port']
+    l3af.vm.network "forwarded_port", guest: 7080, host: cfg['host_l3af_config_port']
+    l3af.vm.network "forwarded_port", guest: 8899, host: cfg['host_l3af_debug_port']
 
-  config.vm.provider "virtualbox" do |vb|
-    vb.memory = "2048"
+    l3af.vm.provider "virtualbox" do |vb|
+      vb.memory = "2048"
+    end
+
+    l3af.vm.box = "ubuntu/focal64"
+    if cfg['traffic_mirroring'] == "true"
+      l3af.vm.network :private_network, ip: "192.168.10.40", :netmask => "255.255.255.0"
+      nat(config)
+    end
+    l3af.vm.hostname = "l3af-local-test.local"
+    l3af.ssh.forward_agent = true
+
+    l3af.vm.synced_folder cfg['host_l3afd_code_dir'], "/home/vagrant/code/l3afd"
+
+    # Add Grafana apt repo
+    l3af.vm.provision "shell", inline: <<-SHELL
+      sudo apt-get install -y apt-transport-https
+      sudo apt-get install -y software-properties-common wget
+      wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
+      echo "deb https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+      sudo apt-get update
+    SHELL
+
+    # Install package dependencies
+    l3af.vm.provision "shell", inline: <<-SHELL
+      apt-get install -y bc \
+        bison \
+        build-essential \
+        clang \
+        curl \
+        exuberant-ctags \
+        flex \
+        gcc-8 \
+        gcc-multilib \
+        gnutls-bin \
+        grafana \
+        jq \
+        libc6-dev \
+        libcurl4-openssl-dev \
+        libelf-dev \
+        libjson-c-dev \
+        libncurses5-dev \
+        libpcap-dev \
+        libssl-dev \
+        linux-headers-generic \
+        linux-tools-common \
+        linux-tools-generic \
+        llvm \
+        net-tools \
+        prometheus \
+        rsync
+    SHELL
+
+    # # Install latest golang version
+    l3af.vm.provision "shell", inline: <<-SHELL
+      arch=`uname -p | cut -d '_' -f 2`
+      os=`uname|tr '[:upper:]' '[:lower:]'`
+      go_filename=`curl -s https://go.dev/dl/?mode=json|jq '.[0].files[].filename'|grep $os|grep $arch|egrep -v "arm|ppc"|tr -d '"'`
+      wget https://go.dev/dl/$go_filename
+      rm -rf /usr/local/go && tar -C /usr/local -xzf $go_filename && rm -f $go_filename
+      echo export PATH=$PATH:/usr/local/go/bin >> /home/vagrant/.bashrc
+      echo export PATH=$PATH:/usr/local/go/bin >> /home/vagrant/.profile
+      echo export PATH=$PATH:/usr/local/go/bin >> /root/.bashrc
+    SHELL
+
+    # Reboot for updated kernel to load
+    l3af.vm.provision :reload
+
+    l3af.vm.provision :shell, path: "provision.sh"
+
+    # Always start test servers because they aren't managed services
+    l3af.vm.provision :shell, path: "start_test_servers.sh", run: 'always'
+    if cfg['traffic_mirroring'] == "true"
+      l3af.vm.provision "shell", inline: <<-SHELL
+        modprobe fou
+        ip fou add port 6080 gue
+        ip link add name gue1 type ipip remote 192.168.10.50 local 192.168.10.40 ttl 255 encap gue encap-sport 6080 encap-dport 6080 encap-csum encap-remcsum
+        ip link set dev gue1 up
+      SHELL
+    end
+
   end
 
-  config.vm.hostname = "l3af-local-test.local"
-  config.ssh.forward_agent = true
-
-  config.vm.synced_folder cfg['host_l3afd_code_dir'], "/home/vagrant/code/l3afd"
-
-  # Add Grafana apt repo
-  config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get install -y apt-transport-https
-    sudo apt-get install -y software-properties-common wget
-    wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
-    echo "deb https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
-    sudo apt-get update
-  SHELL
-
-  # Install package dependencies
-  config.vm.provision "shell", inline: <<-SHELL
-    apt-get install -y bc \
-      bison \
-      build-essential \
-      clang \
-      curl \
-      exuberant-ctags \
-      flex \
-      gcc-8 \
-      gcc-multilib \
-      gnutls-bin \
-      grafana \
-      jq \
-      libc6-dev \
-      libcurl4-openssl-dev \
-      libelf-dev \
-      libjson-c-dev \
-      libncurses5-dev \
-      libpcap-dev \
-      libssl-dev \
-      linux-headers-generic \
-      linux-tools-common \
-      linux-tools-generic \
-      llvm \
-      prometheus \
-      rsync
-  SHELL
-
-  # Install latest golang version
-  config.vm.provision "shell", inline: <<-SHELL
-    arch=`uname -p | cut -d '_' -f 2`
-    os=`uname|tr '[:upper:]' '[:lower:]'`
-    go_filename=`curl -s https://go.dev/dl/?mode=json|jq '.[0].files[].filename'|grep $os|grep $arch|egrep -v "arm|ppc"|tr -d '"'`
-    wget https://go.dev/dl/$go_filename
-    rm -rf /usr/local/go && tar -C /usr/local -xzf $go_filename && rm -f $go_filename
-    echo export PATH=$PATH:/usr/local/go/bin >> /home/vagrant/.bashrc
-    echo export PATH=$PATH:/usr/local/go/bin >> /home/vagrant/.profile
-    echo export PATH=$PATH:/usr/local/go/bin >> /root/.bashrc
-  SHELL
-
-  # Reboot for updated kernel to load
-  config.vm.provision :reload
-
-  config.vm.provision :shell, path: "provision.sh"
-
-  # Always start test servers because they aren't managed services
-  config.vm.provision :shell, path: "start_test_servers.sh", run: 'always'
-
+  if cfg['traffic_mirroring'] == "true"
+    config.vm.define "collector" do |collector|
+      collector.vm.network "private_network", ip: "192.168.10.50", :netmask => "255.255.255.0"
+      collector.vm.box = "ubuntu/focal64"
+      collector.vm.provision "shell", inline: <<-SHELL
+        modprobe fou
+        ip fou add port 6080 gue
+        ip link add name gue1 type ipip remote 192.168.10.40 local 192.168.10.50 ttl 225 encap gue encap-sport 6080 encap-dport 6080 encap-csum encap-remcsum
+        ip link set dev gue1 up
+      SHELL
+    end
+  end
 end

--- a/dev_environment/cfg/traffic_mirroring_payload.json
+++ b/dev_environment/cfg/traffic_mirroring_payload.json
@@ -1,0 +1,60 @@
+[
+    {
+        "host_name": "l3af-local-test",
+        "iface": "enp0s3",
+        "bpf_programs": {
+            "tc_ingress": [
+                {
+                    "name": "traffic-mirroring",
+                    "seq_id": 1,
+                    "artifact": "l3af_traffic_mirroring.tar.gz",
+                    "cmd_start": "mirroring",
+                    "version": "latest",
+                    "map_name": "tc/globals/mirroring_ingress_jmp_table",
+                    "user_program_daemon": true,
+                    "admin_status": "enabled",
+                    "prog_type": "tc",
+                    "cfg_version": 1,
+                    "start_args": {
+                        "src-address": "0.0.0.0",
+                        "tunnel-type": "gue",
+                        "tunnel-local-port": "6080",
+                        "tunnel-remote-port": "6080",
+                        "tunnel-remote-address": "192.168.10.50",
+                        "redirect-to": "enp0s8",
+                        "src-port": "0",
+                        "dst-port": "8080",
+                        "protocol": "tcp,icmp"
+                    },
+                    "monitor_maps": []
+                }
+            ],
+            "tc_egress": [
+                {
+                    "name": "traffic-mirroring",
+                    "seq_id": 1,
+                    "artifact": "l3af_traffic_mirroring.tar.gz",
+                    "cmd_start": "mirroring",
+                    "version": "latest",
+                    "map_name": "tc/globals/mirroring_ingress_jmp_table",
+                    "user_program_daemon": true,
+                    "admin_status": "enabled",
+                    "prog_type": "tc",
+                    "cfg_version": 1,
+                    "start_args": {
+                        "dst-address": "0.0.0.0",
+                        "tunnel-type": "gue",
+                        "tunnel-local-port": "6080",
+                        "tunnel-remote-port": "6080",
+                        "tunnel-remote-address": "192.168.10.50",
+                        "redirect-to": "enp0s8",
+                        "src-port": "8080",
+                        "dst-port": "0",
+                        "protocol": "tcp,icmp"
+                    },
+                    "monitor_maps": []
+                }
+            ]
+        }
+    }
+]

--- a/dev_environment/cfg/traffic_mirroring_payload.json
+++ b/dev_environment/cfg/traffic_mirroring_payload.json
@@ -6,7 +6,7 @@
             "tc_ingress": [
                 {
                     "name": "traffic-mirroring",
-                    "seq_id": 1,
+                    "seq_id": 2,
                     "artifact": "l3af_traffic_mirroring.tar.gz",
                     "cmd_start": "mirroring",
                     "version": "latest",
@@ -32,7 +32,7 @@
             "tc_egress": [
                 {
                     "name": "traffic-mirroring",
-                    "seq_id": 1,
+                    "seq_id": 2,
                     "artifact": "l3af_traffic_mirroring.tar.gz",
                     "cmd_start": "mirroring",
                     "version": "latest",

--- a/dev_environment/config.yaml
+++ b/dev_environment/config.yaml
@@ -6,3 +6,4 @@ configs:
     host_l3af_config_port: '37080'
     host_l3af_debug_port: '38899'
     host_l3afd_code_dir: '/code/l3afd'
+    traffic_mirroring: 'false'

--- a/dev_environment/provision.sh
+++ b/dev_environment/provision.sh
@@ -25,7 +25,12 @@ systemctl enable grafana-server.service
 # Get Linux source code to build our eBPF programs against
 # TODO: Support building against the Linux source from the distro's source
 # package.
-git clone --branch v5.1 --depth 1 https://github.com/torvalds/linux.git /usr/src/linux
+if [ -d "/usr/src/linux" ]
+then
+    echo "Directory /usr/src/linux exists."
+else
+    git clone --branch v5.1 --depth 1 https://github.com/torvalds/linux.git /usr/src/linux
+fi
 LINUX_SRC_DIR=/usr/src/linux
 cd $LINUX_SRC_DIR
 make defconfig
@@ -42,11 +47,16 @@ mkdir -p $BUILD_ARTIFACT_DIR
 cd $BUILD_DIR
 
 # Get the eBPF-Package-Repository repo containing the eBPF programs
-git clone https://github.com/l3af-project/eBPF-Package-Repository.git
+if [ -d "eBPF-Package-Repository" ]
+then
+    echo "Directory eBPF-Package-Repository exists."
+else
+    git clone https://github.com/l3af-project/eBPF-Package-Repository.git
+fi
 cd eBPF-Package-Repository
 
 # declare an array variable
-declare -a progs=("xdp-root" "ratelimiting" "connection-limit" "tc-root" "ipfix-flow-exporter")
+declare -a progs=("xdp-root" "ratelimiting" "connection-limit" "tc-root" "ipfix-flow-exporter" "traffic-mirroring")
 
 # now loop through the above array and build the L3AF eBPF programs
 for prog in "${progs[@]}"

--- a/dev_environment/setup_linux_dev_env.sh
+++ b/dev_environment/setup_linux_dev_env.sh
@@ -204,7 +204,7 @@ fi
 cd eBPF-Package-Repository
 
 # declare an array variable
-declare -a progs=("xdp-root" "ratelimiting" "connection-limit" "tc-root" "ipfix-flow-exporter")
+declare -a progs=("xdp-root" "ratelimiting" "connection-limit" "tc-root" "ipfix-flow-exporter" "traffic-mirroring")
 
 # now loop through the above array and build the L3AF eBPF programs
 for prog in "${progs[@]}"


### PR DESCRIPTION
- Modified Vagrant file to create NAT interface for mirrored traffic, configuration of GUE tunnel, and creating the Collector-VM
- Updated README to include steps for executing traffic-mirroring
- Added L3AFD payload for loading traffic-mirroring 