### PR TITLE
Update l3afd config for initial loading programs from l3afd

### DIFF
--- a/dev_environment/cfg/l3afd.cfg
+++ b/dev_environment/cfg/l3afd.cfg
@@ -25,20 +25,26 @@ metrics-addr: 0.0.0.0:8898
 ebpf-poll-interval: 30s
 n-metric-samples: 20
 
-[xdp-root-program]
+[xdp-root]
+package-name: xdp-root
 artifact: l3af_xdp_root.tar.gz
 command: xdp_root
 ingress-map-name: xdp_root_array
-name: xdp-root
 version: latest
+object-file: xdp_root_kern.o
+entry-function-name: xdp_root
 
-[tc-root-program]
-name: tc-root
+[tc-root]
+package-name: tc-root
 artifact: l3af_tc_root.tar.gz
 ingress-map-name: tc/globals/tc_ingress_root_array
 egress-map-name: tc/globals/tc_egress_root_array
 command: tc_root
 version: latest
+ingress-object-file: tc_root_ingress_kern.o
+egress-object-file: tc_root_egress_kern.o
+ingress-entry-function-name: tc_ingress_root
+egress-entry-function-name: tc_egress_root
 
 [ebpf-chain-debug]
 addr: 0.0.0.0:8899


### PR DESCRIPTION
This PR updates the l3afd.cfg file to support loading eBPF programs from l3afd.