### PR TITLE
Update make commands

### DIFF
--- a/dev_environment/provision.sh
+++ b/dev_environment/provision.sh
@@ -34,6 +34,8 @@ fi
 LINUX_SRC_DIR=/usr/src/linux
 cd $LINUX_SRC_DIR
 make defconfig
+make prepare
+make headers_install
 
 mkdir -p /var/log/tb/l3af
 mkdir -p /var/l3afd


### PR DESCRIPTION
The PR updates the make commands in the development environment. 
In 5.15 kernel, multi level build options are provided. Instead of calling _make_ for recurrsive building, there is prepare step is introduced to resolve all external module dependencies (_make prepare_).
Install sanitised kernel headers (_make header_install_).