### PR TITLE
Update tc root program map path

### DIFF
--- a/dev_environment/cfg/l3afd.cfg
+++ b/dev_environment/cfg/l3afd.cfg
@@ -37,8 +37,8 @@ entry-function-name: xdp_root
 [tc-root]
 package-name: tc-root
 artifact: l3af_tc_root.tar.gz
-ingress-map-name: tc/globals/tc_ingress_root_array
-egress-map-name: tc/globals/tc_egress_root_array
+ingress-map-name: tc_ingress_root_array
+egress-map-name: tc_egress_root_array
 command: tc_root
 version: latest
 ingress-object-file: tc_root_ingress_kern.o


### PR DESCRIPTION
This PR removes tc map path `tc/globals` to keep the map name conssistent. 