### PR TITLE
Adding changes to the dev-env JSON payload for tunnel type in TMT

### DIFF
--- a/dev_environment/cfg/traffic_mirroring_payload.json
+++ b/dev_environment/cfg/traffic_mirroring_payload.json
@@ -16,7 +16,7 @@
                     "cfg_version": 1,
                     "start_args": {
                         "src-address": "0.0.0.0",
-                        "tunnel-type": "gue",
+                        "tunnel-interface-name": "gue1",
                         "tunnel-local-port": "6080",
                         "tunnel-remote-port": "6080",
                         "tunnel-remote-address": "192.168.10.50",
@@ -44,7 +44,7 @@
                     "cfg_version": 1,
                     "start_args": {
                         "dst-address": "0.0.0.0",
-                        "tunnel-type": "gue",
+                        "tunnel-interface-name": "gue1",
                         "tunnel-local-port": "6080",
                         "tunnel-remote-port": "6080",
                         "tunnel-remote-address": "192.168.10.50",

--- a/dev_environment/e2e_test/add_tm_payload.json
+++ b/dev_environment/e2e_test/add_tm_payload.json
@@ -16,7 +16,7 @@
                     "cfg_version": 1,
                     "start_args": {
                         "src-address": "0.0.0.0",
-                        "tunnel-type": "gue",
+                        "tunnel-interface-name": "gue1",
                         "tunnel-local-port": "6080",
                         "tunnel-remote-port": "6081",
                         "tunnel-remote-address": "127.0.0.1",
@@ -43,7 +43,7 @@
                     "cfg_version": 1,
                     "start_args": {
                         "dst-address": "0.0.0.0",
-                        "tunnel-type": "gue",
+                        "tunnel-interface-name": "gue1",
                         "tunnel-local-port": "6080",
                         "tunnel-remote-port": "6081",
                         "tunnel-remote-address": "127.0.0.1",

--- a/dev_environment/e2e_test/exp_output_3.json
+++ b/dev_environment/e2e_test/exp_output_3.json
@@ -169,10 +169,10 @@
           "redirect-to": "lo",
           "src-address": "0.0.0.0",
           "src-port": "0",
+          "tunnel-interface-name": "gue1",
           "tunnel-local-port": "6080",
           "tunnel-remote-address": "127.0.0.1",
-          "tunnel-remote-port": "6081",
-          "tunnel-type": "gue"
+          "tunnel-remote-port": "6081"
         },
         "stop_args": null,
         "status_args": null,
@@ -251,10 +251,10 @@
           "protocol": "tcp,icmp",
           "redirect-to": "lo",
           "src-port": "0",
+          "tunnel-interface-name": "gue1",
           "tunnel-local-port": "6080",
           "tunnel-remote-address": "127.0.0.1",
-          "tunnel-remote-port": "6081",
-          "tunnel-type": "gue"
+          "tunnel-remote-port": "6081"
         },
         "stop_args": null,
         "status_args": null,

--- a/dev_environment/e2e_test/exp_output_4.json
+++ b/dev_environment/e2e_test/exp_output_4.json
@@ -132,10 +132,10 @@
           "redirect-to": "lo",
           "src-address": "0.0.0.0",
           "src-port": "0",
+          "tunnel-interface-name": "gue1",
           "tunnel-local-port": "6080",
           "tunnel-remote-address": "127.0.0.1",
-          "tunnel-remote-port": "6081",
-          "tunnel-type": "gue"
+          "tunnel-remote-port": "6081"
         },
         "stop_args": null,
         "status_args": null,
@@ -177,10 +177,10 @@
           "protocol": "tcp,icmp",
           "redirect-to": "lo",
           "src-port": "0",
+          "tunnel-interface-name": "gue1",
           "tunnel-local-port": "6080",
           "tunnel-remote-address": "127.0.0.1",
-          "tunnel-remote-port": "6081",
-          "tunnel-type": "gue"
+          "tunnel-remote-port": "6081"
         },
         "stop_args": null,
         "status_args": null,

--- a/dev_environment/e2e_test/exp_output_7.json
+++ b/dev_environment/e2e_test/exp_output_7.json
@@ -32,10 +32,10 @@
           "redirect-to": "lo",
           "src-address": "0.0.0.0",
           "src-port": "0",
+          "tunnel-interface-name": "gue1",
           "tunnel-local-port": "6080",
           "tunnel-remote-address": "127.0.0.1",
-          "tunnel-remote-port": "6081",
-          "tunnel-type": "gue"
+          "tunnel-remote-port": "6081"
         },
         "stop_args": null,
         "status_args": null,
@@ -77,10 +77,10 @@
           "protocol": "tcp,icmp",
           "redirect-to": "lo",
           "src-port": "0",
+          "tunnel-interface-name": "gue1",
           "tunnel-local-port": "6080",
           "tunnel-remote-address": "127.0.0.1",
-          "tunnel-remote-port": "6081",
-          "tunnel-type": "gue"
+          "tunnel-remote-port": "6081"
         },
         "stop_args": null,
         "status_args": null,

--- a/dev_environment/setup_linux_dev_env.sh
+++ b/dev_environment/setup_linux_dev_env.sh
@@ -311,7 +311,7 @@ cd $BUILD_DIR
 # Get the eBPF-Package-Repository repo containing the eBPF programs
 if [ ! -d "$BUILD_DIR/eBPF-Package-Repository" ];
 then
-  git clone https://github.com/l3af-project/eBPF-Package-Repository.git
+  git clone -b jay-TMT-tunnel1 https://github.com/jaysheth2/eBPF-Package-Repository.git 
 fi
 cd eBPF-Package-Repository
 

--- a/dev_environment/setup_linux_dev_env.sh
+++ b/dev_environment/setup_linux_dev_env.sh
@@ -311,7 +311,7 @@ cd $BUILD_DIR
 # Get the eBPF-Package-Repository repo containing the eBPF programs
 if [ ! -d "$BUILD_DIR/eBPF-Package-Repository" ];
 then
-  git clone -b jay-TMT-tunnel1 https://github.com/jaysheth2/eBPF-Package-Repository.git 
+  git clone https://github.com/l3af-project/eBPF-Package-Repository.git
 fi
 cd eBPF-Package-Repository
 


### PR DESCRIPTION
We modified TMT code to let the customers specify the encapsulation interface directly. To this end, instead of specifying the tunnel-type in the TMT payload, we now need to specify tunnel-interface-name directly.