### PR TITLE
added support to build ebpf programs using installed kernel headers

### DIFF
--- a/dev_environment/Vagrantfile
+++ b/dev_environment/Vagrantfile
@@ -95,7 +95,9 @@ Vagrant.configure("2") do |config|
         dwarves \
         zlib1g  \
         libelf1 \
-        pkg-config 
+	pkg-config \
+	libbpf-dev \
+	libzstd-dev
     SHELL
 
     # Install Opentelemetry collector

--- a/dev_environment/provision.sh
+++ b/dev_environment/provision.sh
@@ -22,33 +22,11 @@ systemctl daemon-reload
 systemctl start grafana-server
 systemctl enable grafana-server.service
 
-# Get Linux source code to build our eBPF programs against
-# TODO: Support building against the Linux source from the distro's source
-# package.
-if [ -d "/usr/src/linux" ]
-then
-    echo "Directory /usr/src/linux exists."
-else
-    git clone --branch v5.15 --depth 1 https://github.com/torvalds/linux.git /usr/src/linux
-fi
-LINUX_SRC_DIR=/usr/src/linux
-cd $LINUX_SRC_DIR
-sed -i '229a\
-        if [ "${pahole_ver}" -ge "124" ]; then\
-                extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_enum64"\
-        fi' scripts/link-vmlinux.sh
-
-echo "CONFIG_DEBUG_INFO_BTF=y" >> .config
-echo "CONFIG_MODULES=y" >> .config
-make olddefconfig
-make prepare
-yes | make -j$(nproc)
-make headers_install
 
 mkdir -p /var/log/l3af
 mkdir -p /var/l3afd
 
-BUILD_DIR=$LINUX_SRC_DIR/samples/bpf/
+BUILD_DIR=/root
 
 # Where to store the tar.gz build artifacts
 BUILD_ARTIFACT_DIR=/srv/l3afd

--- a/dev_environment/setup_linux_dev_env.sh
+++ b/dev_environment/setup_linux_dev_env.sh
@@ -288,8 +288,7 @@ cd $BUILD_DIR
 # Get the eBPF-Package-Repository repo containing the eBPF programs
 if [ ! -d "$BUILD_DIR/eBPF-Package-Repository" ];
 then
-  #git clone https://github.com/l3af-project/eBPF-Package-Repository.git
-  git clone -b build-without-kernel-clone https://github.com/Atul-source/eBPF-Package-Repository.git
+  git clone https://github.com/l3af-project/eBPF-Package-Repository.git
 fi
 cd eBPF-Package-Repository
 

--- a/dev_environment/setup_linux_dev_env.sh
+++ b/dev_environment/setup_linux_dev_env.sh
@@ -123,7 +123,9 @@ apt-get install -y bc \
       dwarves \
       zlib1g  \
       libelf1 \
-      pkg-config
+      pkg-config \
+      libbpf-dev \
+      libzstd-dev
 
 # Install OTEL collector
 if [ $# -ge 1 ] && [ "$1" == "--otel-collector" ]; then
@@ -263,28 +265,6 @@ else
   fi
 fi
 
-# Get Linux source code to build our eBPF programs against
-if [ -d "/usr/src/linux" ];
-then
-  echo "Linux source code already exists, skipping download"
-else
-  git clone --branch v5.15 --depth 1 https://github.com/torvalds/linux.git /usr/src/linux
-fi
-
-LINUX_SRC_DIR=/usr/src/linux
-cd $LINUX_SRC_DIR
-sed -i '229a\
-        if [ "${pahole_ver}" -ge "124" ]; then\
-                extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_enum64"\
-        fi' scripts/link-vmlinux.sh
-
-echo "CONFIG_DEBUG_INFO_BTF=y" >> .config
-echo "CONFIG_MODULES=y" >> .config
-make olddefconfig
-make prepare
-yes | make -j$(nproc)
-make headers_install
-
 if [ ! -d "/var/log/l3af" ];
 then
   mkdir -p /var/log/l3af
@@ -294,7 +274,7 @@ then
   mkdir -p /var/l3afd
 fi
 
-BUILD_DIR=$LINUX_SRC_DIR/samples/bpf/
+BUILD_DIR=/root
 
 # Where to store the tar.gz build artifacts
 BUILD_ARTIFACT_DIR=/srv/l3afd
@@ -308,7 +288,8 @@ cd $BUILD_DIR
 # Get the eBPF-Package-Repository repo containing the eBPF programs
 if [ ! -d "$BUILD_DIR/eBPF-Package-Repository" ];
 then
-  git clone https://github.com/l3af-project/eBPF-Package-Repository.git
+  #git clone https://github.com/l3af-project/eBPF-Package-Repository.git
+  git clone -b build-without-kernel-clone https://github.com/Atul-source/eBPF-Package-Repository.git
 fi
 cd eBPF-Package-Repository
 


### PR DESCRIPTION
In this PR, I’ve removed the requirement to clone the kernel for building the eBPF programs. This should help optimize both our build process and the runtime of the end-to-end tests.