### PR TITLE
update path of bpftool

### DIFF
--- a/dev_environment/setup_linux_dev_env.sh
+++ b/dev_environment/setup_linux_dev_env.sh
@@ -301,6 +301,7 @@ then
   cd bpftool/src
   yes | make
   cp bpftool /usr/local/bin/
+  cp bpftool /usr/sbin/
   cd ../../
   rm -rf bpftool
 fi


### PR DESCRIPTION
This PR addresses the issue where the bpftool binary is not present in `/usr/sbin`. It copies the newly built binary to this location to resolve the issue.